### PR TITLE
chore(lsp): Update to most recent release of LSP

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -11,6 +11,7 @@ An implementation of the [Language Server Protocol](https://microsoft.github.io/
 npm i -g @influxdata/flux-lsp-cli
 ```
 
+
 # Core functionality
 
 The core of the flux parsing library can be found [here](https://github.com/influxdata/flux-lsp) which is compiled into WASM for consumption in this tool.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/flux-lsp-cli",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -31,9 +31,9 @@
       }
     },
     "@influxdata/flux-lsp-node": {
-      "version": "0.5.11",
-      "resolved": "https://registry.npmjs.org/@influxdata/flux-lsp-node/-/flux-lsp-node-0.5.11.tgz",
-      "integrity": "sha512-X8vynsbgJue9Zzx4+j1aGdjU+g5uxlKDwOXWmWbtQGawJArEh9t60PELOaEUcwy1yLodMN8d18Hp5A/RonGLmw=="
+      "version": "0.5.20",
+      "resolved": "https://registry.npmjs.org/@influxdata/flux-lsp-node/-/flux-lsp-node-0.5.20.tgz",
+      "integrity": "sha512-TdMGRFU6OutqaCJScBEyanWeldGdVjCkUy59J2GlV4sU4HqNwT6J7GnF3ZjZU+1wbWk0T7k6gFElaqUvkkzSrA=="
     },
     "@jest/types": {
       "version": "25.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/flux-lsp-cli",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "description": "Flux cli LSP server",
   "repository": {
     "type": "git",
@@ -19,7 +19,7 @@
   "author": "Brandon Farmer <bthesorceror@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "@influxdata/flux-lsp-node": "0.5.11",
+    "@influxdata/flux-lsp-node": "0.5.20",
     "axios": "^0.19.2",
     "through2": "^3.0.1",
     "yargs": "^15.3.1"


### PR DESCRIPTION
Closes #11 

Updates the `flux-lsp-node` dependency to the most recent version
