### PR TITLE
build: add checks for semantic commits and PR titles

### DIFF
--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -1,0 +1,3 @@
+# docs: https://github.com/probot/semantic-pull-requests#configuration
+# Always validate the PR title AND all the commits
+titleAndCommits: true


### PR DESCRIPTION
Helps with https://github.com/influxdata/flux-lsp/issues/168

Adds `.github/semantic.yml` to configure the [`semantic PR app`](https://github.com/zeke/semantic-pull-requests#configuration) to check for semantic commits and PR titles.