### PR TITLE
build: Release v0.7.12

### DIFF
--- a/bump-version.sh
+++ b/bump-version.sh
@@ -46,8 +46,9 @@ echo "Checking out branch \`$branch_name\`"
 echo "Incrementing version"
 echo "$version -> $new_version"
 
-git add .
-git commit -m "build: Release $new_version"
+git commit -am "build: Release $new_version"
+npm add @influxdata/flux-lsp-node
+git commit -am "build: Import latest version of flux-lsp-node"
 git push -u origin $branch_name
 
 hub pull-request -o \

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,9 +31,9 @@
       }
     },
     "@influxdata/flux-lsp-node": {
-      "version": "0.5.27",
-      "resolved": "https://registry.npmjs.org/@influxdata/flux-lsp-node/-/flux-lsp-node-0.5.27.tgz",
-      "integrity": "sha512-UhwR7B1VOVG1KYCsOIQK0/YpvSIQWNrhhJ3mIwRUbVBZ2EvK1rl5HhO9myHhLiwMeoH01dZx0fCQ5F5DCfsN2Q=="
+      "version": "0.5.28",
+      "resolved": "https://registry.npmjs.org/@influxdata/flux-lsp-node/-/flux-lsp-node-0.5.28.tgz",
+      "integrity": "sha512-iESo6cL8HUbI2krNKd8UpPsENPKWMAq0W174ZUabs2+So+VS/gYrkDkNNIZgxd4PTw3LueLyZvvDx/2syhb+5A=="
     },
     "@jest/types": {
       "version": "25.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/flux-lsp-cli",
-  "version": "0.7.11",
+  "version": "0.7.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/flux-lsp-cli",
-  "version": "0.7.11",
+  "version": "0.7.12",
   "description": "Flux cli LSP server",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "author": "Brandon Farmer <bthesorceror@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "@influxdata/flux-lsp-node": "^0.5.27",
+    "@influxdata/flux-lsp-node": "^0.5.28",
     "axios": "^0.21.1",
     "through2": "^3.0.1",
     "yargs": "^15.3.1"


### PR DESCRIPTION
- Change version from v0.7.11 to v0.7.12
- Upgrade flux-lsp-node to [v0.5.28](https://github.com/influxdata/flux-lsp/releases/tag/v0.5.28)
- Automate importing the new lsp release in `bump-version.sh`