### PR TITLE
build: Import latest version of flux-lsp

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@influxdata/flux-lsp-cli",
-  "version": "0.7.19",
+  "version": "0.7.20",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@influxdata/flux-lsp-cli",
-      "version": "0.7.19",
+      "version": "0.7.20",
       "license": "MIT",
       "dependencies": {
         "@influxdata/flux-lsp-node": "^0.5.35",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.7.20",
       "license": "MIT",
       "dependencies": {
-        "@influxdata/flux-lsp-node": "^0.5.35",
+        "@influxdata/flux-lsp-node": "^0.5.37",
         "axios": "^0.21.1",
         "through2": "^3.0.1",
         "yargs": "^15.3.1"
@@ -55,9 +55,9 @@
       }
     },
     "node_modules/@influxdata/flux-lsp-node": {
-      "version": "0.5.35",
-      "resolved": "https://registry.npmjs.org/@influxdata/flux-lsp-node/-/flux-lsp-node-0.5.35.tgz",
-      "integrity": "sha512-Zg4woDxrqJaX2Qa9Hlg5uq3TIGpueGstVkJ7ayYA8+Qfr/ftfRKpR1o0RMGd4gaWx+n3aWwMnfbne0glzLu0Qg=="
+      "version": "0.5.37",
+      "resolved": "https://registry.npmjs.org/@influxdata/flux-lsp-node/-/flux-lsp-node-0.5.37.tgz",
+      "integrity": "sha512-rhV6lMwq/gV8iT1UvQvr6k7a0TNbOnrRWb8e8lJDxXB1Zi+3q1slRAA4Ld+C2OVvEojIxanrCwuFLVoxcrXoyQ=="
     },
     "node_modules/@jest/types": {
       "version": "25.4.0",
@@ -3673,9 +3673,9 @@
       }
     },
     "@influxdata/flux-lsp-node": {
-      "version": "0.5.35",
-      "resolved": "https://registry.npmjs.org/@influxdata/flux-lsp-node/-/flux-lsp-node-0.5.35.tgz",
-      "integrity": "sha512-Zg4woDxrqJaX2Qa9Hlg5uq3TIGpueGstVkJ7ayYA8+Qfr/ftfRKpR1o0RMGd4gaWx+n3aWwMnfbne0glzLu0Qg=="
+      "version": "0.5.37",
+      "resolved": "https://registry.npmjs.org/@influxdata/flux-lsp-node/-/flux-lsp-node-0.5.37.tgz",
+      "integrity": "sha512-rhV6lMwq/gV8iT1UvQvr6k7a0TNbOnrRWb8e8lJDxXB1Zi+3q1slRAA4Ld+C2OVvEojIxanrCwuFLVoxcrXoyQ=="
     },
     "@jest/types": {
       "version": "25.4.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "author": "Brandon Farmer <bthesorceror@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "@influxdata/flux-lsp-node": "^0.5.35",
+    "@influxdata/flux-lsp-node": "^0.5.37",
     "axios": "^0.21.1",
     "through2": "^3.0.1",
     "yargs": "^15.3.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/flux-lsp-cli",
-  "version": "0.7.19",
+  "version": "0.7.20",
   "description": "Flux cli LSP server",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Last one didn't import the correct lsp version due to an npm bug. This corrects that.